### PR TITLE
Design change to how to UR hub and removed participant screening link

### DIFF
--- a/app/views/things-to-do/conduct-inclusive-research/how-to-conduct-inclusive-research/index.html
+++ b/app/views/things-to-do/conduct-inclusive-research/how-to-conduct-inclusive-research/index.html
@@ -41,14 +41,32 @@
        <li><a id="ellen-doyle" href="#"><img src="/images/ellen-doyle.jpg" alt="ellen doyle"></a></li>
       </ul>
 
-      <h2 class="nhsuk-heading-s nhsuk-u-margin-bottom-4"><a href="how-to-conduct-inclusive-research/general-user-research-tips">General user research tips</a></h2>
-      <h2 class="nhsuk-heading-s nhsuk-u-margin-bottom-4"><a href="how-to-conduct-inclusive-research/research-about-mental-health">Research about mental health</a></h2>
-      <h2 class="nhsuk-heading-s nhsuk-u-margin-bottom-4"><a href="how-to-conduct-inclusive-research/research-with-trans-people">Research with trans people</a></h2>
-      <h2 class="nhsuk-heading-s nhsuk-u-margin-bottom-4"><a href="how-to-conduct-inclusive-research/research-with-neurodiverse-people">Research with neurodiverse people</a></h2>
-      <h2 class="nhsuk-heading-s nhsuk-u-margin-bottom-4"><a href="how-to-conduct-inclusive-research/research-with-deaf-people-or-people-with-hearing-loss">Research with Deaf people or people with hearing loss</a></h2>
-      <h2 class="nhsuk-heading-s nhsuk-u-margin-bottom-4"><a href="how-to-conduct-inclusive-research/research-with-people-with-physical-or-motor-disabilities">Research with people with physical or motor disabilities</a></h2>
-      <h2 class="nhsuk-heading-s nhsuk-u-margin-bottom-4"><a href="how-to-conduct-inclusive-research/research-with-people-with-sight-loss">Research with people with sight loss</a></h2>
-
+  <nav class="nhsuk-contents-list" role="navigation" aria-label="Pages in this guide">
+               <h2 class="nhsuk-u-visually-hidden">Contents</h2>
+               <ol class="nhsuk-contents-list__list">
+                 <li class="nhsuk-contents-list__item">
+                   <a class="nhsuk-contents-list__link" href="how-to-conduct-inclusive-research/general-user-research-tips">General user research tips</a>
+                 </li>
+                 <li class="nhsuk-contents-list__item">
+                   <a class="nhsuk-contents-list__link" href="how-to-conduct-inclusive-research/research-about-mental-health">Research about mental health</a>
+                 </li>
+                 <li class="nhsuk-contents-list__item">
+                   <a class="nhsuk-contents-list__link" href="how-to-conduct-inclusive-research/research-with-trans-people">Research with trans people</a>
+                 </li>
+                 <li class="nhsuk-contents-list__item">
+                   <a class="nhsuk-contents-list__link" href="how-to-conduct-inclusive-research/research-with-neurodiverse-people">Research with neurodiverse people</a>
+                 </li>
+                 <li class="nhsuk-contents-list__item">
+                   <a class="nhsuk-contents-list__link" href="how-to-conduct-inclusive-research/research-with-deaf-people-or-people-with-hearing-loss">Research with Deaf people or people with hearing loss</a>
+                 </li>
+                 <li class="nhsuk-contents-list__item">
+                   <a class="nhsuk-contents-list__link" href="how-to-conduct-inclusive-research/research-with-people-with-physical-or-motor-disabilities">Research with people with physical or motor disabilities</a>
+                 </li>
+                 <li class="nhsuk-contents-list__item">
+                   <a class="nhsuk-contents-list__link" href="how-to-conduct-inclusive-research/research-with-people-with-sight-loss">Research with people with sight loss</a>
+                 </li>
+               </ol>
+        </nav>
     </div>
   </div>
 {% endblock %}

--- a/app/views/things-to-do/conduct-inclusive-research/index.html
+++ b/app/views/things-to-do/conduct-inclusive-research/index.html
@@ -28,7 +28,7 @@
   <div class="nhsuk-grid-row">
 
       <div class="nhsuk-grid-column-one-third">
-      <h2 class="nhsuk-heading-s nhsuk-u-margin-bottom-4"><a href="conduct-inclusive-research/how-to-write-recruitment-briefs">How to write recruitment briefs</a></h2>
+      <h2 class="nhsuk-heading-s nhsuk-u-margin-bottom-4"><a href="conduct-inclusive-research/how-to-write-recruitment-briefs/structure-and-examples-for-recruitment-briefs">How to write recruitment briefs</a></h2>
       <p>A template to structure your brief, with examples.</p>
       </div>
       <div class="nhsuk-grid-column-one-third">
@@ -40,5 +40,5 @@
       <p>Things teams have found when doing inclusive user research.</p>
     </div>
   </div>
-    
+
 {% endblock %}


### PR DESCRIPTION
## Description
To avoid confusion it's best to link straight to the recruitment brief structure information instead of the hub for writing recruitment briefs as we do not have any content for participant screening advice so far and the empty link is confusing.
